### PR TITLE
fix simple typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Inspired by [Front-end-Developers-Interview-Questions](https://github.com/h5bp/F
 * Where to look when trying to reduce cloud costs without reducing capacity?
 * Name the "Big Three" cloud providers
   * AWS
-  * GCE
+  * GCP
   * Azure
 
 ##### AWS Questions


### PR DESCRIPTION
GCE (Google Compute Engine) is more similar to the specific EC2 service
in AWS. GCP (Google Cloud Platform) is at the same level of service as
AWS itself, so GCP is probably what we want here.